### PR TITLE
refactor: remove double escaping for after-replace logic

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -123,7 +123,7 @@ spec:
       action: fetch:template
       targetPath: ../.
       input:
-        url: {{ 'https://${{ parameters.gitlabHost }}/${{ parameters.gitlabOrganization }}/${{ parameters.allLocationRepositoryName }}' }}
+        url: 'https://${{ parameters.gitlabHost }}/${{ parameters.gitlabOrganization }}/${{ parameters.allLocationRepositoryName }}'
         
 
     # Step1: Create catalog-info file for the component
@@ -139,7 +139,7 @@ spec:
           componentName: ${{ parameters.componentName }}
           componentLifecycle: ${{ parameters.componentLifecycle }}
           description: ${{ parameters.description }}
-          destination: {{ '"${{ parameters.gitlabHost }}/${{ parameters.gitlabOrganization }}/${{ parameters.repositoryName }}"' }}
+          destination: '"${{ parameters.gitlabHost }}/${{ parameters.gitlabOrganization }}/${{ parameters.repositoryName }}"'
           host: ${{ parameters.gitlabHost }}
           owner: ${{ parameters.componentOwner }}
           orgName: ${{ parameters.gitlabOrganization }}
@@ -155,12 +155,12 @@ spec:
       name: Open PR with for all-catalog
       action: publish:gitlab:merge-request
       input: 
-        repoUrl: {{ '"${{ parameters.gitlabHost }}?repo=${{ parameters.allLocationRepositoryName }}&owner=${{ parameters.gitlabOrganization }}"' }}
+        repoUrl: '"${{ parameters.gitlabHost }}?repo=${{ parameters.allLocationRepositoryName }}&owner=${{ parameters.gitlabOrganization }}"'
         title: Open PR with catalog-info.yaml
         description: Open PR with catalog-info.yaml
-        branchName: {{ '"${{ parameters.componentName }}-create"' }}
+        branchName: '"${{ parameters.componentName }}-create"'
         sourcePath: ./patch
-        targetPath: {{ '"./${{ parameters.repositoryName }}"' }}
+        targetPath: '"./${{ parameters.repositoryName }}"'
         commitAction: create
         removeSourceBranch: true    
   output:

--- a/template.yaml
+++ b/template.yaml
@@ -139,7 +139,7 @@ spec:
           componentName: ${{ parameters.componentName }}
           componentLifecycle: ${{ parameters.componentLifecycle }}
           description: ${{ parameters.description }}
-          destination: '"${{ parameters.gitlabHost }}/${{ parameters.gitlabOrganization }}/${{ parameters.repositoryName }}"'
+          destination: "${{ parameters.gitlabHost }}/${{ parameters.gitlabOrganization }}/${{ parameters.repositoryName }}"
           host: ${{ parameters.gitlabHost }}
           owner: ${{ parameters.componentOwner }}
           orgName: ${{ parameters.gitlabOrganization }}
@@ -155,12 +155,12 @@ spec:
       name: Open PR with for all-catalog
       action: publish:gitlab:merge-request
       input: 
-        repoUrl: '"${{ parameters.gitlabHost }}?repo=${{ parameters.allLocationRepositoryName }}&owner=${{ parameters.gitlabOrganization }}"'
+        repoUrl: "${{ parameters.gitlabHost }}?repo=${{ parameters.allLocationRepositoryName }}&owner=${{ parameters.gitlabOrganization }}"
         title: Open PR with catalog-info.yaml
         description: Open PR with catalog-info.yaml
-        branchName: '"${{ parameters.componentName }}-create"'
+        branchName: "${{ parameters.componentName }}-create"
         sourcePath: ./patch
-        targetPath: '"./${{ parameters.repositoryName }}"'
+        targetPath: "./${{ parameters.repositoryName }}"
         commitAction: create
         removeSourceBranch: true    
   output:

--- a/template.yaml
+++ b/template.yaml
@@ -135,20 +135,20 @@ spec:
         targetPath: ./patch
         values:
           applicationType: "API"
-          component_id: {{ '${{ parameters.componentName }}' }}
-          componentName: {{ '${{ parameters.componentName }}' }}
-          componentLifecycle: {{ '${{ parameters.componentLifecycle }}' }}
-          description: {{ '${{ parameters.description }}' }}
+          component_id: ${{ parameters.componentName }}
+          componentName: ${{ parameters.componentName }}
+          componentLifecycle: ${{ parameters.componentLifecycle }}
+          description: ${{ parameters.description }}
           destination: {{ '"${{ parameters.gitlabHost }}/${{ parameters.gitlabOrganization }}/${{ parameters.repositoryName }}"' }}
-          host: {{ '${{ parameters.gitlabHost }}' }}
-          owner: {{ '${{ parameters.componentOwner }}' }}
-          orgName: {{ '${{ parameters.gitlabOrganization }}' }}
-          repoName: {{ '${{ parameters.repositoryName }}' }}
-          system: {{ '${{ parameters.system }}' }}
-          apiType: {{ '${{ parameters.apiType }}' }}
-          apiPathText: {{ '${{ parameters.apiPathText }}' }}
-          allLocationGitlabOrganization: {{ '${{ parameters.allLocationGitlabOrganization }}' }}
-          allLocationRepositoryName: {{ '${{ parameters.allLocationRepositoryName }}' }}
+          host: ${{ parameters.gitlabHost }}
+          owner: ${{ parameters.componentOwner }}
+          orgName: ${{ parameters.gitlabOrganization }}
+          repoName: ${{ parameters.repositoryName }}
+          system: ${{ parameters.system }}
+          apiType: ${{ parameters.apiType }}
+          apiPathText: ${{ parameters.apiPathText }}
+          allLocationGitlabOrganization: ${{ parameters.allLocationGitlabOrganization }}
+          allLocationRepositoryName: ${{ parameters.allLocationRepositoryName }}
     
     # Merge catalog-info and techdocs into EXISTING repo   - only EXISTING REPO
     - id: publishComponentMergeRequest
@@ -165,5 +165,5 @@ spec:
         removeSourceBranch: true    
   output:
     links:
-      - url: {{ '${{ steps.publishComponentMergeRequest.output.mergeRequestUrl }}' }}
+      - url: ${{ steps.publishComponentMergeRequest.output.mergeRequestUrl }}
         title: 'Component merge request'


### PR DESCRIPTION
Replace {{ '${{ ... }}' }} patterns with ${{ ... }} since the gitlab init playbook now uses ansible.builtin.replace instead of builtin.template. Placeholders like {{ gitlab_host }} are retained for the replace job.